### PR TITLE
Fix homepage: s/xml-rpc/xmlrpc/

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "zf2",
         "xmlrpc"
     ],
-    "homepage": "https://github.com/zendframework/zend-xml-rpc",
+    "homepage": "https://github.com/zendframework/zend-xmlrpc",
     "autoload": {
         "psr-4": {
             "Zend\\XmlRpc\\": "src/"


### PR DESCRIPTION
Updates the homepage in `composer.json` to reference `xmlrpc` instead of `xml-rpc`.
