### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     - secure: "tE/9gTe0U+QN1mlCC7Wr70RaOHn3Mtn8ZZTjN0LuhDhXTe3Hs197DNNv3vxNSXRavIRuLi1mIEiEu1uzV4qlnUx01Uj+G+jCshYLrZIQ8TxVJEXB1r1tFrNosg4s1hpxDQn7O5O0VzOEB8G01PobCUmPNTDPGi77xj8HyE+SCLQPnnNPwp4gJtifS+bBOmAe//A0aOA14ArzJLi4xfEKCC2yoSUawob8xX9LbMfLwq8/IEPYtLqN9rvk5qpc2/uhb7Hrqk7Nq8Xt6Gv2ixgDkfYup7BswAamtT5M4m02mXBneYqC2OYDeuStv8kkaIIjTCKxOOPzseRgHJgXLxnRNbJjG7fLaTpWYtl4ZqevGZlp+GrRGHMsQO4wxXMAM0U476nLzNlQDw3xEH9dKpf/QRM1bsP2b45fxHRklRjek+KXIF0bE7q5+jkOeHzg/z05CF6EMSjZuuI+qoUrdZub/R6pTxwhqBzDzUxZjTY3gj5+qlTlvn/B18tCXNsHjsFX75Boy1ST45ai/6ow1veyaWk9H/wIJEqEk54gWDsonpwpGgQjQcoZ58QRi9SKxv0hBFB+No+k2fFnQc0pvTJKa/3Pk+k2I77BvaqtZxC6eqXHKOiDvaR/ywBAIPLBEHL7Fm4Xeu80voNAPlcRV+5qD7ptPaV6gxqeNm1rM81SZHA="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.6
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.
