### PR TITLE
Fix memory leak: headers added by the http client are added to the same request object at each request

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -205,10 +205,14 @@ class Client implements ServerClient
         }
 
         $headers = $httpRequest->getHeaders();
-        $headers->addHeaders([
-            'Content-Type: text/xml; charset=utf-8',
-            'Accept: text/xml',
-        ]);
+        
+        if (!$headers->get('Content-Type')) {
+            $headers->addHeaderLine('Content-Type', 'text/xml; charset=utf-8');
+        }
+        
+        if (!$headers->get('Accept')) {
+            $headers->addHeaderLine('Accept', 'text/xml');
+        }
 
         if (!$headers->get('user-agent')) {
             $headers->addHeaderLine('user-agent', 'Zend_XmlRpc_Client');

--- a/src/Client.php
+++ b/src/Client.php
@@ -205,11 +205,11 @@ class Client implements ServerClient
         }
 
         $headers = $httpRequest->getHeaders();
-        
+
         if (!$headers->get('Content-Type')) {
             $headers->addHeaderLine('Content-Type', 'text/xml; charset=utf-8');
         }
-        
+
         if (!$headers->get('Accept')) {
             $headers->addHeaderLine('Accept', 'text/xml');
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -205,10 +205,14 @@ class Client implements ServerClient
         }
 
         $headers = $httpRequest->getHeaders();
-        $headers->addHeaders([
-            'Content-Type: text/xml; charset=utf-8',
-            'Accept: text/xml',
-        ]);
+
+        if (!$headers->get('Content-Type')) {
+            $headers->addHeaderLine('Content-Type', 'text/xml; charset=utf-8');
+        }
+
+        if (!$headers->get('Accept')) {
+            $headers->addHeaderLine('Accept', 'text/xml');
+        }
 
         if (!$headers->get('user-agent')) {
             $headers->addHeaderLine('user-agent', 'Zend_XmlRpc_Client');

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -603,6 +603,36 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedUserAgent, $this->httpClient->getHeader('user-agent'));
     }
 
+    public function testContentTypeAutomaticallySet()
+    {
+        $this->assertFalse(
+            $this->httpClient->getHeader('Content-Type'),
+            'Content-Type is null if no request was made'
+        );
+
+        $expectedContentType = 'text/xml; charset=utf-8';
+        $this->httpClient->setHeaders(['Content-Type' => $expectedContentType]);
+
+        $this->setServerResponseTo(true);
+        $this->assertTrue($this->xmlrpcClient->call('method'));
+        $this->assertSame($expectedContentType, $this->httpClient->getHeader(''));
+    }
+
+    public function testAcceptAutomaticallySet()
+    {
+        $this->assertFalse(
+            $this->httpClient->getHeader('Accept'),
+            'Accept header is null if no request was made'
+        );
+
+        $expectedAccept = 'text/xml';
+        $this->httpClient->setHeaders(['Accept' => $expectedAccept]);
+
+        $this->setServerResponseTo(true);
+        $this->assertTrue($this->xmlrpcClient->call('method'));
+        $this->assertSame($expectedAccept, $this->httpClient->getHeader(''));
+    }
+
     /**
      * @group ZF-8478
      */

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -603,6 +603,36 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedUserAgent, $this->httpClient->getHeader('user-agent'));
     }
 
+    public function testContentTypeAutomaticallySet()
+    {
+        $this->assertFalse(
+            $this->httpClient->getHeader('Content-Type'),
+            'Content-Type is null if no request was made'
+        );
+
+        $expectedContentType = 'text/xml; charset=utf-8';
+        $this->httpClient->setHeaders(['Content-Type' => $expectedContentType]);
+
+        $this->setServerResponseTo(true);
+        $this->assertTrue($this->xmlrpcClient->call('method'));
+        $this->assertSame($expectedContentType, $this->httpClient->getHeader('Content-Type'));
+    }
+
+    public function testAcceptAutomaticallySet()
+    {
+        $this->assertFalse(
+            $this->httpClient->getHeader('Accept'),
+            'Accept header is null if no request was made'
+        );
+
+        $expectedAccept = 'text/xml';
+        $this->httpClient->setHeaders(['Accept' => $expectedAccept]);
+
+        $this->setServerResponseTo(true);
+        $this->assertTrue($this->xmlrpcClient->call('method'));
+        $this->assertSame($expectedAccept, $this->httpClient->getHeader('Accept'));
+    }
+
     /**
      * @group ZF-8478
      */


### PR DESCRIPTION
Headers are no longer added every time. They used to be added regardless, which caused the headers array to grow infinitely.