### PR TITLE
Replace deprecated each()

### DIFF
--- a/src/AbstractValue.php
+++ b/src/AbstractValue.php
@@ -440,11 +440,15 @@ abstract class AbstractValue
     protected static function extractTypeAndValue(\SimpleXMLElement $xml, &$type, &$value)
     {
         // Casting is necessary to work with strict-typed systems
-        foreach((array) $xml as $type => $value) break;
+        foreach ((array) $xml as $type => $value) {
+            break;
+        }
         if (!$type and $value === null) {
             $namespaces = ['ex' => 'http://ws.apache.org/xmlrpc/namespaces/extensions'];
             foreach ($namespaces as $namespaceName => $namespaceUri) {
-                foreach ((array)$xml->children($namespaceUri) as $type => $value) break;
+                foreach ((array)$xml->children($namespaceUri) as $type => $value) {
+                    break;
+                }
                 if ($type !== null) {
                     $type = $namespaceName . ':' . $type;
                     break;

--- a/src/AbstractValue.php
+++ b/src/AbstractValue.php
@@ -440,14 +440,11 @@ abstract class AbstractValue
     protected static function extractTypeAndValue(\SimpleXMLElement $xml, &$type, &$value)
     {
         // Casting is necessary to work with strict-typed systems
-        $xmlAsArray = (array) $xml;
-        list($type, $value) = each($xmlAsArray);
+        foreach((array) $xml as $type => $value) break;
         if (!$type and $value === null) {
             $namespaces = ['ex' => 'http://ws.apache.org/xmlrpc/namespaces/extensions'];
             foreach ($namespaces as $namespaceName => $namespaceUri) {
-                $namespaceXml = $xml->children($namespaceUri);
-                $namespaceXmlAsArray = (array) $namespaceXml;
-                list($type, $value) = each($namespaceXmlAsArray);
+                foreach ((array)$xml->children($namespaceUri) as $type => $value) break;
                 if ($type !== null) {
                     $type = $namespaceName . ':' . $type;
                     break;

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -263,17 +263,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $sx = new \SimpleXMLElement($xml);
 
         $result = $sx->xpath('//methodName');
-        $count = 0;
-        while (list(, $node) = each($result)) {
-            ++$count;
-        }
+        $count = count($result);
         $this->assertEquals(1, $count, $xml);
 
         $result = $sx->xpath('//params');
-        $count = 0;
-        while (list(, $node) = each($result)) {
-            ++$count;
-        }
+        $count = count($result);
         $this->assertEquals(1, $count, $xml);
 
         $methodName = (string) $sx->methodName;


### PR DESCRIPTION
Fixes #28 

Using of each() was also the cause of incompatibility with PHP7.2:
ErrorException: "The each() function is deprecated. This message will be suppressed on further calls"

Changing to foreach() and count() makes the package compatible with the latest PHP 7.2.1