### PR TITLE
Complete PHP 7.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       env:
         - DEPS=locked
         - TEST_COVERAGE=true
-        - LEGACY_DEPS="phpunit/phpunit"
+        - LEGACY_DEPS="phpunit/phpunit zendframework/zend-code"
     - php: 5.6
       env:
         - DEPS=latest
@@ -36,7 +36,7 @@ matrix:
       env:
         - DEPS=locked
         - CS_CHECK=true
-        - LEGACY_DEPS="phpunit/phpunit"
+        - LEGACY_DEPS="phpunit/phpunit zendframework/zend-code"
     - php: 7
       env:
         - DEPS=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,10 @@ branches:
 cache:
   directories:
     - $HOME/.composer/cache
-    - $HOME/.local
-    - zf-mkdoc-theme
 
 env:
   global:
     - COMPOSER_ARGS="--no-interaction"
-    - SITE_URL=https://zendframework.github.io/zend-xmlrpc
-    - GH_USER_NAME="Matthew Weier O'Phinney"
-    - GH_USER_EMAIL=matthew@weierophinney.net
-    - GH_REF=github.com/zendframework/zend-xmlrpc.git
-    - secure: "tE/9gTe0U+QN1mlCC7Wr70RaOHn3Mtn8ZZTjN0LuhDhXTe3Hs197DNNv3vxNSXRavIRuLi1mIEiEu1uzV4qlnUx01Uj+G+jCshYLrZIQ8TxVJEXB1r1tFrNosg4s1hpxDQn7O5O0VzOEB8G01PobCUmPNTDPGi77xj8HyE+SCLQPnnNPwp4gJtifS+bBOmAe//A0aOA14ArzJLi4xfEKCC2yoSUawob8xX9LbMfLwq8/IEPYtLqN9rvk5qpc2/uhb7Hrqk7Nq8Xt6Gv2ixgDkfYup7BswAamtT5M4m02mXBneYqC2OYDeuStv8kkaIIjTCKxOOPzseRgHJgXLxnRNbJjG7fLaTpWYtl4ZqevGZlp+GrRGHMsQO4wxXMAM0U476nLzNlQDw3xEH9dKpf/QRM1bsP2b45fxHRklRjek+KXIF0bE7q5+jkOeHzg/z05CF6EMSjZuuI+qoUrdZub/R6pTxwhqBzDzUxZjTY3gj5+qlTlvn/B18tCXNsHjsFX75Boy1ST45ai/6ow1veyaWk9H/wIJEqEk54gWDsonpwpGgQjQcoZ58QRi9SKxv0hBFB+No+k2fFnQc0pvTJKa/3Pk+k2I77BvaqtZxC6eqXHKOiDvaR/ywBAIPLBEHL7Fm4Xeu80voNAPlcRV+5qD7ptPaV6gxqeNm1rM81SZHA="
 
 matrix:
   fast_finish: true
@@ -32,8 +25,7 @@ matrix:
       env:
         - DEPS=locked
         - TEST_COVERAGE=true
-        - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
-        - PATH="$HOME/.local/bin:$PATH"
+        - LEGACY_DEPS="phpunit/phpunit"
     - php: 5.6
       env:
         - DEPS=latest
@@ -44,7 +36,26 @@ matrix:
       env:
         - DEPS=locked
         - CS_CHECK=true
+        - LEGACY_DEPS="phpunit/phpunit"
     - php: 7
+      env:
+        - DEPS=latest
+    - php: 7.1
+      env:
+        - DEPS=lowest
+    - php: 7.1
+      env:
+        - DEPS=locked
+    - php: 7.1
+      env:
+        - DEPS=latest
+    - php: 7.2
+      env:
+        - DEPS=lowest
+    - php: 7.2
+      env:
+        - DEPS=locked
+    - php: 7.2
       env:
         - DEPS=latest
     - php: hhvm 
@@ -60,28 +71,23 @@ matrix:
     - php: hhvm
 
 notifications:
-  irc: "irc.freenode.org#zftalk.dev"
   email: false
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - travis_retry composer self-update
 
 install:
+  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
+  - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer require --dev $COMPOSER_ARGS satooshi/php-coveralls:^1.0 ; fi
-  - travis_retry composer install $COMPOSER_ARGS
-  - composer show
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer require --dev $COMPOSER_ARGS php-coveralls/php-coveralls:^2.0 ; fi
+  - stty cols 120 && composer show
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; fi
   - if [[ $TEST_COVERAGE != 'true' ]]; then composer test ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
-  - if [[ $DEPLOY_DOCS == "true" && "$TRAVIS_TEST_RESULT" == "0" ]]; then wget -O theme-installer.sh "https://raw.githubusercontent.com/zendframework/zf-mkdoc-theme/master/theme-installer.sh" ; chmod 755 theme-installer.sh ; ./theme-installer.sh ; fi
-
-after_success:
-  - if [[ $DEPLOY_DOCS == "true" ]]; then echo "Preparing to build and deploy documentation" ; ./zf-mkdoc-theme/deploy.sh ; echo "Completed deploying documentation" ; fi
 
 after_script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer upload-coverage ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then php vendor/bin/php-coveralls -v ; fi

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
         "zendframework/zendxml": "^1.0.2"
     },
     "require-dev": {
-        "phpunit/PHPUnit": "^4.8",
-        "squizlabs/php_codesniffer": "^2.3.1"
+        "phpunit/PHPUnit": "^5.7.25 || ^6.4.4",
+        "zendframework/zend-coding-standard": "~1.0.0"
     },
     "suggest": {
         "zendframework/zend-cache": "To support Zend\\XmlRpc\\Server\\Cache usage"

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
             "ZendTest\\XmlRpc\\": "test/"
         },
         "files": [
+            "test/autoload.php",
             "test/TestAsset/functions.php"
         ]
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b7ea9034b1672b95c99795411139d43",
+    "content-hash": "470a0ee42ee63377343141e0be074048",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -39,16 +39,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.10",
+            "version": "v2.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d"
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/634bae8e911eefa89c1abfbf1b66da679ac8f54d",
-                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
                 "shasum": ""
             },
             "require": {
@@ -83,7 +83,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-13T16:27:32+00:00"
+            "time": "2017-09-27T21:40:39+00:00"
         },
         {
             "name": "psr/container",
@@ -136,27 +136,27 @@
         },
         {
             "name": "zendframework/zend-code",
-            "version": "3.1.0",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-code.git",
-                "reference": "2899c17f83a7207f2d7f53ec2f421204d3beea27"
+                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/2899c17f83a7207f2d7f53ec2f421204d3beea27",
-                "reference": "2899c17f83a7207f2d7f53ec2f421204d3beea27",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/6b1059db5b368db769e4392c6cb6cc139e56640d",
+                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || 7.0.0 - 7.0.4 || ^7.0.6",
+                "php": "^7.1",
                 "zendframework/zend-eventmanager": "^2.6 || ^3.0"
             },
             "require-dev": {
                 "doctrine/annotations": "~1.0",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^4.8.21",
-                "squizlabs/php_codesniffer": "^2.5",
+                "phpunit/phpunit": "^6.2.3",
+                "zendframework/zend-coding-standard": "^1.0.0",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "suggest": {
@@ -166,8 +166,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev",
-                    "dev-develop": "3.2-dev"
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
                 }
             },
             "autoload": {
@@ -185,7 +185,7 @@
                 "code",
                 "zf2"
             ],
-            "time": "2016-10-24T13:23:32+00:00"
+            "time": "2017-10-20T15:21:32+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -287,35 +287,35 @@
         },
         {
             "name": "zendframework/zend-http",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-http.git",
-                "reference": "09f4d279f46d86be63171ff62ee0f79eca878678"
+                "reference": "78aa510c0ea64bfb2aa234f50c4f232c9531acfa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/09f4d279f46d86be63171ff62ee0f79eca878678",
-                "reference": "09f4d279f46d86be63171ff62ee0f79eca878678",
+                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/78aa510c0ea64bfb2aa234f50c4f232c9531acfa",
+                "reference": "78aa510c0ea64bfb2aa234f50c4f232c9531acfa",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "zendframework/zend-loader": "^2.5",
-                "zendframework/zend-stdlib": "^2.5 || ^3.0",
-                "zendframework/zend-uri": "^2.5",
-                "zendframework/zend-validator": "^2.5"
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-loader": "^2.5.1",
+                "zendframework/zend-stdlib": "^3.1 || ^2.7.7",
+                "zendframework/zend-uri": "^2.5.2",
+                "zendframework/zend-validator": "^2.10.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0",
+                "phpunit/phpunit": "^6.4.1 || ^5.7.15",
                 "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-config": "^2.5"
+                "zendframework/zend-config": "^3.1 || ^2.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev",
-                    "dev-develop": "2.7-dev"
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
                 }
             },
             "autoload": {
@@ -330,10 +330,13 @@
             "description": "provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
             "homepage": "https://github.com/zendframework/zend-http",
             "keywords": [
+                "ZendFramework",
                 "http",
-                "zf2"
+                "http client",
+                "zend",
+                "zf"
             ],
-            "time": "2017-01-31T14:41:02+00:00"
+            "time": "2017-10-13T12:06:24+00:00"
         },
         {
             "name": "zendframework/zend-loader",
@@ -569,16 +572,16 @@
         },
         {
             "name": "zendframework/zend-validator",
-            "version": "2.9.2",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-validator.git",
-                "reference": "a58dbe8463b93de0d650e296d56cb7da4a129ff3"
+                "reference": "010084ddbd33299bf51ea6f0e07f8f4e8bd832a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/a58dbe8463b93de0d650e296d56cb7da4a129ff3",
-                "reference": "a58dbe8463b93de0d650e296d56cb7da4a129ff3",
+                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/010084ddbd33299bf51ea6f0e07f8f4e8bd832a8",
+                "reference": "010084ddbd33299bf51ea6f0e07f8f4e8bd832a8",
                 "shasum": ""
             },
             "require": {
@@ -597,7 +600,7 @@
                 "zendframework/zend-i18n": "^2.6",
                 "zendframework/zend-math": "^2.6",
                 "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-                "zendframework/zend-session": "^2.6.2",
+                "zendframework/zend-session": "^2.8",
                 "zendframework/zend-uri": "^2.5"
             },
             "suggest": {
@@ -607,14 +610,14 @@
                 "zendframework/zend-i18n-resources": "Translations of validator messages",
                 "zendframework/zend-math": "Zend\\Math component, required by the Csrf validator",
                 "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
-                "zendframework/zend-session": "Zend\\Session component, required by the Csrf validator",
+                "zendframework/zend-session": "Zend\\Session component, ^2.8; required by the Csrf validator",
                 "zendframework/zend-uri": "Zend\\Uri component, required by the Uri and Sitemap\\Loc validators"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.9-dev",
-                    "dev-develop": "2.10-dev"
+                    "dev-master": "2.10-dev",
+                    "dev-develop": "2.11-dev"
                 },
                 "zf": {
                     "component": "Zend\\Validator",
@@ -636,7 +639,7 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2017-07-20T16:44:59+00:00"
+            "time": "2017-08-22T14:19:23+00:00"
         },
         {
             "name": "zendframework/zendxml",
@@ -687,32 +690,32 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -737,20 +740,167 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "name": "myclabs/deep-copy",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
@@ -791,33 +941,39 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.2.2",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157"
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/4aada1f93c72c35e22fb1383b47fee43b8f1d157",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.3.0",
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -836,20 +992,20 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-08T06:39:58+00:00"
+            "time": "2017-11-27T17:38:31+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.3.0",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fb3933512008d8162b3cdf9e18dba9309b7c3773",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
@@ -883,37 +1039,37 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-06-03T08:32:36+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
                 "sebastian/comparator": "^1.1|^2.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -946,43 +1102,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^2.0.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -997,7 +1154,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1008,20 +1165,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06T15:47:00+00:00"
+            "time": "2017-12-06T09:29:45+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -1055,7 +1212,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1149,29 +1306,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.11",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1194,45 +1351,57 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.36",
+            "version": "6.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
+                "reference": "83d27937a310f2984fd575686138597147bdc7df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/83d27937a310f2984fd575686138597147bdc7df",
+                "reference": "83d27937a310f2984fd575686138597147bdc7df",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.2.2",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^1.0.9",
+                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^2.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
             },
             "suggest": {
-                "phpunit/php-invoker": "~1.1"
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -1240,7 +1409,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "6.5.x-dev"
                 }
             },
             "autoload": {
@@ -1266,30 +1435,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-06-21T08:07:12+00:00"
+            "time": "2017-12-17T06:31:19+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
+                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.5"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1297,7 +1469,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -1312,7 +1484,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1322,34 +1494,79 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02T06:51:40+00:00"
+            "time": "2018-01-06T05:45:45+00:00"
         },
         {
-            "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "11c07feade1d65453e06df3b3b90171d6d982087"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/11c07feade1d65453e06df3b3b90171d6d982087",
+                "reference": "11c07feade1d65453e06df3b3b90171d6d982087",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/diff": "^2.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -1380,38 +1597,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2018-01-12T06:34:42+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1438,32 +1655,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1488,34 +1705,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18T05:49:44+00:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1555,27 +1772,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17T09:04:28+00:00"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1583,7 +1800,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1606,32 +1823,124 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.5",
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-08-03T12:35:26+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1659,23 +1968,73 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03T07:41:43+00:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1694,7 +2053,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21T13:59:46+00:00"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1775,59 +2134,44 @@
             "time": "2017-05-22T02:43:20+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.3.6",
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "ddc23324e6cfe066f3dd34a37ff494fa80b617ed"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ddc23324e6cfe066f3dd34a37ff494fa80b617ed",
-                "reference": "ddc23324e6cfe066f3dd34a37ff494fa80b617ed",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "symfony/console": "~2.8|~3.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2017-07-23T12:43:26+00:00"
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1878,6 +2222,35 @@
                 "validate"
             ],
             "time": "2016-11-23T20:04:58+00:00"
+        },
+        {
+            "name": "zendframework/zend-coding-standard",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-coding-standard.git",
+                "reference": "893316d2904e93f1c74c1384b6d7d57778299cb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-coding-standard/zipball/893316d2904e93f1c74c1384b6d7d57778299cb6",
+                "reference": "893316d2904e93f1c74c1384b6d7d57778299cb6",
+                "shasum": ""
+            },
+            "require": {
+                "squizlabs/php_codesniffer": "^2.7"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Zend Framework coding standard",
+            "keywords": [
+                "Coding Standard",
+                "zf"
+            ],
+            "time": "2016-11-09T21:30:43+00:00"
         }
     ],
     "aliases": [],

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,19 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="Zend Framework coding standard">
-    <description>Zend Framework coding standard</description>
-
-    <!-- display progress -->
-    <arg value="p"/>
-    <arg name="colors"/>
-
-    <!-- inherit rules from: -->
-    <rule ref="PSR2"/>
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
-        <properties>
-            <property name="ignoreBlankLines" value="false"/>
-        </properties>
-    </rule>
+<ruleset name="Zend Framework Coding Standard">
+    <rule ref="./vendor/zendframework/zend-coding-standard/ruleset.xml"/>
 
     <!-- Paths to check -->
     <file>src</file>

--- a/src/AbstractValue.php
+++ b/src/AbstractValue.php
@@ -440,11 +440,15 @@ abstract class AbstractValue
     protected static function extractTypeAndValue(\SimpleXMLElement $xml, &$type, &$value)
     {
         // Casting is necessary to work with strict-typed systems
-        foreach((array) $xml as $type => $value) break;
+        foreach ((array) $xml as $type => $value) {
+            break;
+        }
         if (!$type and $value === null) {
             $namespaces = ['ex' => 'http://ws.apache.org/xmlrpc/namespaces/extensions'];
             foreach ($namespaces as $namespaceName => $namespaceUri) {
-                foreach ((array)$xml->children($namespaceUri) as $type => $value) break;
+                foreach ((array)$xml->children($namespaceUri) as $type => $value) {
+                    break;
+                }
                 if ($type !== null) {
                     $type = $namespaceName . ':' . $type;
                     break;

--- a/src/AbstractValue.php
+++ b/src/AbstractValue.php
@@ -440,14 +440,11 @@ abstract class AbstractValue
     protected static function extractTypeAndValue(\SimpleXMLElement $xml, &$type, &$value)
     {
         // Casting is necessary to work with strict-typed systems
-        $xmlAsArray = (array) $xml;
-        list($type, $value) = each($xmlAsArray);
+        foreach((array) $xml as $type => $value) break;
         if (!$type and $value === null) {
             $namespaces = ['ex' => 'http://ws.apache.org/xmlrpc/namespaces/extensions'];
             foreach ($namespaces as $namespaceName => $namespaceUri) {
-                $namespaceXml = $xml->children($namespaceUri);
-                $namespaceXmlAsArray = (array) $namespaceXml;
-                list($type, $value) = each($namespaceXmlAsArray);
+                foreach ((array)$xml->children($namespaceUri) as $type => $value) break;
                 if ($type !== null) {
                     $type = $namespaceName . ':' . $type;
                     break;

--- a/src/AbstractValue.php
+++ b/src/AbstractValue.php
@@ -92,7 +92,7 @@ abstract class AbstractValue
      */
     public static function getGenerator()
     {
-        if (!static::$generator) {
+        if (! static::$generator) {
             if (extension_loaded('xmlwriter')) {
                 static::$generator = new Generator\XmlWriter();
             } else {
@@ -142,7 +142,7 @@ abstract class AbstractValue
      */
     public function saveXml()
     {
-        if (!$this->xml) {
+        if (! $this->xml) {
             $this->generateXml();
             $this->xml = (string) $this->getGenerator();
         }
@@ -244,7 +244,7 @@ abstract class AbstractValue
             }
             return static::getXmlRpcTypeByValue(get_object_vars($value));
         } elseif (is_array($value)) {
-            if (!empty($value) && is_array($value) && (array_keys($value) !== range(0, count($value) - 1))) {
+            if (! empty($value) && is_array($value) && (array_keys($value) !== range(0, count($value) - 1))) {
                 return self::XMLRPC_TYPE_STRUCT;
             }
             return self::XMLRPC_TYPE_ARRAY;
@@ -393,7 +393,7 @@ abstract class AbstractValue
                 foreach ($value->member as $member) {
                     // @todo? If a member doesn't have a <value> tag, we don't add it to the struct
                     // Maybe we want to throw an exception here ?
-                    if (!isset($member->value) or !isset($member->name)) {
+                    if (! isset($member->value) or ! isset($member->name)) {
                         continue;
                     }
                     $values[(string) $member->name] = static::xmlStringToNativeXmlRpc($member->value);
@@ -443,7 +443,7 @@ abstract class AbstractValue
         foreach ((array) $xml as $type => $value) {
             break;
         }
-        if (!$type and $value === null) {
+        if (! $type and $value === null) {
             $namespaces = ['ex' => 'http://ws.apache.org/xmlrpc/namespaces/extensions'];
             foreach ($namespaces as $namespaceName => $namespaceUri) {
                 foreach ((array)$xml->children($namespaceUri) as $type => $value) {
@@ -457,7 +457,7 @@ abstract class AbstractValue
         }
 
         // If no type was specified, the default is string
-        if (!$type) {
+        if (! $type) {
             $type = self::XMLRPC_TYPE_STRING;
             if (empty($value) and preg_match('#^<value>.*</value>$#', $xml->asXML())) {
                 $value = str_replace(['<value>', '</value>'], '', $xml->asXML());

--- a/src/Client.php
+++ b/src/Client.php
@@ -211,15 +211,15 @@ class Client implements ServerClient
 
         $headers = $httpRequest->getHeaders();
 
-        if (!$headers->has('Content-Type')) {
+        if (! $headers->has('Content-Type')) {
             $headers->addHeaderLine('Content-Type', 'text/xml; charset=utf-8');
         }
 
-        if (!$headers->has('Accept')) {
+        if (! $headers->has('Accept')) {
             $headers->addHeaderLine('Accept', 'text/xml');
         }
 
-        if (!$headers->has('user-agent')) {
+        if (! $headers->has('user-agent')) {
             $headers->addHeaderLine('user-agent', 'Zend_XmlRpc_Client');
         }
 
@@ -227,7 +227,7 @@ class Client implements ServerClient
         $http->setRawBody($xml);
         $httpResponse = $http->setMethod('POST')->send();
 
-        if (!$httpResponse->isSuccess()) {
+        if (! $httpResponse->isSuccess()) {
             /**
              * Exception thrown when an HTTP error occurs
              */
@@ -255,7 +255,7 @@ class Client implements ServerClient
      */
     public function call($method, $params = [])
     {
-        if (!$this->skipSystemLookup() && ('system.' != substr($method, 0, 7))) {
+        if (! $this->skipSystemLookup() && ('system.' != substr($method, 0, 7))) {
             // Ensure empty array/struct params are cast correctly
             // If system.* methods are not available, bypass. (ZF-2978)
             $success = true;
@@ -278,7 +278,7 @@ class Client implements ServerClient
                     AbstractValue::XMLRPC_TYPE_STRUCT,
                 ];
 
-                if (!is_array($params)) {
+                if (! is_array($params)) {
                     $params = [$params];
                 }
                 foreach ($params as $key => $param) {
@@ -289,7 +289,7 @@ class Client implements ServerClient
                     if (count($signatures) > 1) {
                         $type = AbstractValue::getXmlRpcTypeByValue($param);
                         foreach ($signatures as $signature) {
-                            if (!is_array($signature)) {
+                            if (! is_array($signature)) {
                                 continue;
                             }
                             if (isset($signature['parameters'][$key])) {
@@ -304,7 +304,7 @@ class Client implements ServerClient
                         $type = null;
                     }
 
-                    if (empty($type) || !in_array($type, $validTypes)) {
+                    if (empty($type) || ! in_array($type, $validTypes)) {
                         $type = AbstractValue::AUTO_DETECT_TYPE;
                     }
 

--- a/src/Client/ServerIntrospection.php
+++ b/src/Client/ServerIntrospection.php
@@ -127,7 +127,7 @@ class ServerIntrospection
     public function getMethodSignature($method)
     {
         $signature = $this->system->methodSignature($method);
-        if (!is_array($signature)) {
+        if (! is_array($signature)) {
             $error = 'Invalid signature for method "' . $method . '"';
             throw new Exception\IntrospectException($error);
         }

--- a/src/Client/ServerProxy.php
+++ b/src/Client/ServerProxy.php
@@ -54,7 +54,7 @@ class ServerProxy
     public function __get($namespace)
     {
         $namespace = ltrim("$this->namespace.$namespace", '.');
-        if (!isset($this->cache[$namespace])) {
+        if (! isset($this->cache[$namespace])) {
             $this->cache[$namespace] = new $this($this->client, $namespace);
         }
         return $this->cache[$namespace];

--- a/src/Fault.php
+++ b/src/Fault.php
@@ -177,7 +177,7 @@ class Fault
      */
     public function loadXml($fault)
     {
-        if (!is_string($fault)) {
+        if (! is_string($fault)) {
             throw new Exception\InvalidArgumentException('Invalid XML provided to fault');
         }
 
@@ -188,7 +188,7 @@ class Fault
             // Unsecure XML
             throw new Exception\RuntimeException('Failed to parse XML fault: ' .  $e->getMessage(), 500, $e);
         }
-        if (!$xml instanceof SimpleXMLElement) {
+        if (! $xml instanceof SimpleXMLElement) {
             $errors = libxml_get_errors();
             $errors = array_reduce($errors, function ($result, $item) {
                 if (empty($result)) {
@@ -202,12 +202,12 @@ class Fault
         libxml_use_internal_errors($xmlErrorsFlag);
 
         // Check for fault
-        if (!$xml->fault) {
+        if (! $xml->fault) {
             // Not a fault
             return false;
         }
 
-        if (!$xml->fault->value->struct) {
+        if (! $xml->fault->value->struct) {
             // not a proper fault
             throw new Exception\InvalidArgumentException('Invalid fault structure', 500);
         }

--- a/src/Request.php
+++ b/src/Request.php
@@ -116,7 +116,7 @@ class Request
      */
     public function setMethod($method)
     {
-        if (!is_string($method) || !preg_match('/^[a-z0-9_.:\\\\\/]+$/i', $method)) {
+        if (! is_string($method) || ! preg_match('/^[a-z0-9_.:\\\\\/]+$/i', $method)) {
             $this->fault = new Fault(634, 'Invalid method name ("' . $method . '")');
             $this->fault->setEncoding($this->getEncoding());
             return false;
@@ -196,13 +196,13 @@ class Request
             $types      = [];
             $wellFormed = true;
             foreach ($argv[0] as $arg) {
-                if (!is_array($arg) || !isset($arg['value'])) {
+                if (! is_array($arg) || ! isset($arg['value'])) {
                     $wellFormed = false;
                     break;
                 }
                 $params[] = $arg['value'];
 
-                if (!isset($arg['type'])) {
+                if (! isset($arg['type'])) {
                     $xmlRpcValue = AbstractValue::getXmlRpcValue($arg['value']);
                     $arg['type'] = $xmlRpcValue->getType();
                 }
@@ -276,7 +276,7 @@ class Request
      */
     public function loadXml($request)
     {
-        if (!is_string($request)) {
+        if (! is_string($request)) {
             $this->fault = new Fault(635);
             $this->fault->setEncoding($this->getEncoding());
             return false;
@@ -308,7 +308,7 @@ class Request
             libxml_use_internal_errors($xmlErrorsFlag);
             return false;
         }
-        if (!$xml instanceof SimpleXMLElement || $error) {
+        if (! $xml instanceof SimpleXMLElement || $error) {
             // Not valid XML
             $this->fault = new Fault(631);
             $this->fault->setEncoding($this->getEncoding());
@@ -327,11 +327,11 @@ class Request
         $this->method = (string) $xml->methodName;
 
         // Check for parameters
-        if (!empty($xml->params)) {
+        if (! empty($xml->params)) {
             $types = [];
             $argv  = [];
             foreach ($xml->params->children() as $param) {
-                if (!isset($param->value)) {
+                if (! isset($param->value)) {
                     $this->fault = new Fault(633);
                     $this->fault->setEncoding($this->getEncoding());
                     return false;
@@ -391,7 +391,7 @@ class Request
                 $value = $param['value'];
                 $type  = $param['type'] ?: AbstractValue::AUTO_DETECT_TYPE;
 
-                if (!$value instanceof AbstractValue) {
+                if (! $value instanceof AbstractValue) {
                     $value = AbstractValue::getXmlRpcValue($value, $type);
                 }
                 $params[] = $value;

--- a/src/Request/Http.php
+++ b/src/Request/Http.php
@@ -47,7 +47,7 @@ class Http extends XmlRpcRequest
         ErrorHandler::start();
         $xml = file_get_contents('php://input');
         ErrorHandler::stop();
-        if (!$xml) {
+        if (! $xml) {
             $this->fault = new Fault(630);
             return;
         }

--- a/src/Request/Stdin.php
+++ b/src/Request/Stdin.php
@@ -38,13 +38,13 @@ class Stdin extends XmlRpcRequest
     public function __construct()
     {
         $fh = fopen('php://stdin', 'r');
-        if (!$fh) {
+        if (! $fh) {
             $this->fault = new Fault(630);
             return;
         }
 
         $xml = '';
-        while (!feof($fh)) {
+        while (! feof($fh)) {
             $xml .= fgets($fh);
         }
         fclose($fh);

--- a/src/Response.php
+++ b/src/Response.php
@@ -147,7 +147,7 @@ class Response
      */
     public function loadXml($response)
     {
-        if (!is_string($response)) {
+        if (! is_string($response)) {
             $this->fault = new Fault(650);
             $this->fault->setEncoding($this->getEncoding());
             return false;
@@ -161,7 +161,7 @@ class Response
             return false;
         }
 
-        if (!empty($xml->fault)) {
+        if (! empty($xml->fault)) {
             // fault response
             $this->fault = new Fault();
             $this->fault->setEncoding($this->getEncoding());
@@ -177,7 +177,7 @@ class Response
         }
 
         try {
-            if (!isset($xml->params) || !isset($xml->params->param) || !isset($xml->params->param->value)) {
+            if (! isset($xml->params) || ! isset($xml->params->param) || ! isset($xml->params->param->value)) {
                 throw new Exception\ValueException('Missing XML-RPC value in XML');
             }
             $valueXml = $xml->params->param->value->asXML();

--- a/src/Response/Http.php
+++ b/src/Response/Http.php
@@ -23,7 +23,7 @@ class Http extends XmlRpcResponse
      */
     public function __toString()
     {
-        if (!headers_sent()) {
+        if (! headers_sent()) {
             header('Content-Type: text/xml; charset=' . strtolower($this->getEncoding()));
         }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -146,7 +146,7 @@ class Server extends AbstractServer
     public function __call($method, $params)
     {
         $system = $this->getSystem();
-        if (!method_exists($system, $method)) {
+        if (! method_exists($system, $method)) {
             throw new Server\Exception\BadMethodCallException('Unknown instance method called on server: ' . $method);
         }
         return call_user_func_array([$system, $method], $params);
@@ -170,7 +170,7 @@ class Server extends AbstractServer
      */
     public function addFunction($function, $namespace = '')
     {
-        if (!is_string($function) && !is_array($function)) {
+        if (! is_string($function) && ! is_array($function)) {
             throw new Server\Exception\InvalidArgumentException('Unable to attach function; invalid', 611);
         }
 
@@ -182,7 +182,7 @@ class Server extends AbstractServer
 
         $function = (array) $function;
         foreach ($function as $func) {
-            if (!is_string($func) || !function_exists($func)) {
+            if (! is_string($func) || ! function_exists($func)) {
                 throw new Server\Exception\InvalidArgumentException('Unable to attach function; invalid', 611);
             }
             $reflection = Reflection::reflectFunction($func, $argv, $namespace);
@@ -209,7 +209,7 @@ class Server extends AbstractServer
      */
     public function setClass($class, $namespace = '', $argv = null)
     {
-        if (is_string($class) && !class_exists($class)) {
+        if (is_string($class) && ! class_exists($class)) {
             throw new Server\Exception\InvalidArgumentException('Invalid method class', 610);
         }
 
@@ -233,7 +233,7 @@ class Server extends AbstractServer
      */
     public function fault($fault = null, $code = 404)
     {
-        if (!$fault instanceof \Exception) {
+        if (! $fault instanceof \Exception) {
             $fault = (string) $fault;
             if (empty($fault)) {
                 $fault = 'Unknown Error';
@@ -280,7 +280,7 @@ class Server extends AbstractServer
     public function handle($request = false)
     {
         // Get request
-        if ((!$request || !$request instanceof Request)
+        if ((! $request || ! $request instanceof Request)
             && (null === ($request = $this->getRequest()))
         ) {
             $request = new Request\Http();
@@ -303,7 +303,7 @@ class Server extends AbstractServer
         $response->setEncoding($this->getEncoding());
         $this->response = $response;
 
-        if (!$this->returnResponse) {
+        if (! $this->returnResponse) {
             echo $response;
             return;
         }
@@ -323,7 +323,7 @@ class Server extends AbstractServer
      */
     public function loadFunctions($definition)
     {
-        if (!is_array($definition) && (!$definition instanceof Definition)) {
+        if (! is_array($definition) && (! $definition instanceof Definition)) {
             if (is_object($definition)) {
                 $type = get_class($definition);
             } else {
@@ -394,11 +394,11 @@ class Server extends AbstractServer
     {
         if (is_string($request) && class_exists($request)) {
             $request = new $request();
-            if (!$request instanceof Request) {
+            if (! $request instanceof Request) {
                 throw new Server\Exception\InvalidArgumentException('Invalid request class');
             }
             $request->setEncoding($this->getEncoding());
-        } elseif (!$request instanceof Request) {
+        } elseif (! $request instanceof Request) {
             throw new Server\Exception\InvalidArgumentException('Invalid request object');
         }
 
@@ -435,7 +435,7 @@ class Server extends AbstractServer
      */
     public function setResponseClass($class)
     {
-        if (!class_exists($class) || !is_subclass_of($class, 'Zend\XmlRpc\Response')) {
+        if (! class_exists($class) || ! is_subclass_of($class, 'Zend\XmlRpc\Response')) {
             throw new Server\Exception\InvalidArgumentException('Invalid response class');
         }
         $this->responseClass = $class;
@@ -536,7 +536,7 @@ class Server extends AbstractServer
         $method = $request->getMethod();
 
         // Check for valid method
-        if (!$this->table->hasMethod($method)) {
+        if (! $this->table->hasMethod($method)) {
             throw new Server\Exception\RuntimeException('Method "' . $method . '" does not exist', 620);
         }
 
@@ -568,7 +568,7 @@ class Server extends AbstractServer
                 break;
             }
         }
-        if (!$matched) {
+        if (! $matched) {
             throw new Server\Exception\RuntimeException('Calling parameters do not match signature', 623);
         }
 

--- a/src/Server/Fault.php
+++ b/src/Server/Fault.php
@@ -64,7 +64,7 @@ class Fault extends \Zend\XmlRpc\Fault
         parent::__construct($code, $message);
 
         // Notify exception observers, if present
-        if (!empty(static::$observers)) {
+        if (! empty(static::$observers)) {
             foreach (array_keys(static::$observers) as $observer) {
                 $observer::observe($this);
             }
@@ -90,7 +90,7 @@ class Fault extends \Zend\XmlRpc\Fault
      */
     public static function attachFaultException($classes)
     {
-        if (!is_array($classes)) {
+        if (! is_array($classes)) {
             $classes = (array) $classes;
         }
 
@@ -109,7 +109,7 @@ class Fault extends \Zend\XmlRpc\Fault
      */
     public static function detachFaultException($classes)
     {
-        if (!is_array($classes)) {
+        if (! is_array($classes)) {
             $classes = (array) $classes;
         }
 
@@ -134,11 +134,11 @@ class Fault extends \Zend\XmlRpc\Fault
      */
     public static function attachObserver($class)
     {
-        if (!is_string($class) || !class_exists($class) || !is_callable([$class, 'observe'])) {
+        if (! is_string($class) || ! class_exists($class) || ! is_callable([$class, 'observe'])) {
             return false;
         }
 
-        if (!isset(static::$observers[$class])) {
+        if (! isset(static::$observers[$class])) {
             static::$observers[$class] = true;
         }
 
@@ -153,7 +153,7 @@ class Fault extends \Zend\XmlRpc\Fault
      */
     public static function detachObserver($class)
     {
-        if (!isset(static::$observers[$class])) {
+        if (! isset(static::$observers[$class])) {
             return false;
         }
 

--- a/src/Server/System.php
+++ b/src/Server/System.php
@@ -52,7 +52,7 @@ class System
     public function methodHelp($method)
     {
         $table = $this->server->getDispatchTable();
-        if (!$table->hasMethod($method)) {
+        if (! $table->hasMethod($method)) {
             throw new Exception\InvalidArgumentException('Method "' . $method . '" does not exist', 640);
         }
 
@@ -69,7 +69,7 @@ class System
     public function methodSignature($method)
     {
         $table = $this->server->getDispatchTable();
-        if (!$table->hasMethod($method)) {
+        if (! $table->hasMethod($method)) {
             throw new Exception\InvalidArgumentException('Method "' . $method . '" does not exist', 640);
         }
         $method = $table->getMethod($method)->toArray();
@@ -98,13 +98,13 @@ class System
         $responses = [];
         foreach ($methods as $method) {
             $fault = false;
-            if (!is_array($method)) {
+            if (! is_array($method)) {
                 $fault = $this->server->fault('system.multicall expects each method to be a struct', 601);
-            } elseif (!isset($method['methodName'])) {
+            } elseif (! isset($method['methodName'])) {
                 $fault = $this->server->fault('Missing methodName: ' . var_export($methods, 1), 602);
-            } elseif (!isset($method['params'])) {
+            } elseif (! isset($method['params'])) {
                 $fault = $this->server->fault('Missing params', 603);
-            } elseif (!is_array($method['params'])) {
+            } elseif (! is_array($method['params'])) {
                 $fault = $this->server->fault('Params must be an array', 604);
             } else {
                 if ('system.multicall' == $method['methodName']) {
@@ -113,7 +113,7 @@ class System
                 }
             }
 
-            if (!$fault) {
+            if (! $fault) {
                 try {
                     $request = new \Zend\XmlRpc\Request();
                     $request->setMethod($method['methodName']);

--- a/src/Value/AbstractCollection.php
+++ b/src/Value/AbstractCollection.php
@@ -24,7 +24,7 @@ abstract class AbstractCollection extends AbstractValue
         foreach ($values as $key => $value) {
             // If the elements of the given array are not Zend\XmlRpc\Value objects,
             // we need to convert them as such (using auto-detection from PHP value)
-            if (!$value instanceof parent) {
+            if (! $value instanceof parent) {
                 $value = static::getXmlRpcValue($value, self::AUTO_DETECT_TYPE);
             }
             $this->value[$key] = $value;

--- a/src/Value/Base64.php
+++ b/src/Value/Base64.php
@@ -23,7 +23,7 @@ class Base64 extends AbstractScalar
         $this->type = self::XMLRPC_TYPE_BASE64;
 
         $value = (string) $value;    // Make sure this value is string
-        if (!$alreadyEncoded) {
+        if (! $alreadyEncoded) {
             $value = base64_encode($value);     // We encode it in base64
         }
         $this->value = $value;

--- a/test/BigIntegerValueTest.php
+++ b/test/BigIntegerValueTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\XmlRpc;
 
+use PHPUnit\Framework\TestCase;
 use Zend\XmlRpc\AbstractValue;
 use Zend\XmlRpc\Value\BigInteger;
 use Zend\XmlRpc\Generator\GeneratorInterface as Generator;
@@ -16,7 +17,7 @@ use Zend\XmlRpc\Generator\GeneratorInterface as Generator;
 /**
  * @group      Zend_XmlRpc
  */
-class BigIntegerValueTest extends \PHPUnit_Framework_TestCase
+class BigIntegerValueTest extends TestCase
 {
     public function setUp()
     {

--- a/test/FaultTest.php
+++ b/test/FaultTest.php
@@ -9,13 +9,15 @@
 
 namespace ZendTest\XmlRpc;
 
+use PHPUnit\Framework\TestCase;
 use Zend\XmlRpc\AbstractValue;
-use Zend\XmlRpc;
+use Zend\XmlRpc\Exception;
+use Zend\XmlRpc\Fault;
 
 /**
  * @group      Zend_XmlRpc
  */
-class FaultTest extends \PHPUnit_Framework_TestCase
+class FaultTest extends TestCase
 {
     /**
      * @var XmlRpc\Fault
@@ -28,7 +30,7 @@ class FaultTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         AbstractValue::setGenerator(null);
-        $this->fault = new XmlRpc\Fault();
+        $this->fault = new Fault();
     }
 
     /**
@@ -149,25 +151,29 @@ class FaultTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadXmlThrowsExceptionOnInvalidInput()
     {
-        $this->setExpectedException('Zend\XmlRpc\Exception\InvalidArgumentException', 'Failed to parse XML fault');
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Failed to parse XML fault');
         $parsed = $this->fault->loadXml('foo');
     }
 
     public function testLoadXmlThrowsExceptionOnInvalidInput2()
     {
-        $this->setExpectedException('Zend\XmlRpc\Exception\InvalidArgumentException', 'Invalid fault structure');
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid fault structure');
         $this->assertFalse($this->fault->loadXml('<methodResponse><fault/></methodResponse>'));
     }
 
     public function testLoadXmlThrowsExceptionOnInvalidInput3()
     {
-        $this->setExpectedException('Zend\XmlRpc\Exception\InvalidArgumentException', 'Invalid fault structure');
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid fault structure');
         $this->fault->loadXml('<methodResponse><fault/></methodResponse>');
     }
 
     public function testLoadXmlThrowsExceptionOnInvalidInput4()
     {
-        $this->setExpectedException('Zend\XmlRpc\Exception\InvalidArgumentException', 'Fault code and string required');
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Fault code and string required');
         $this->fault->loadXml('<methodResponse><fault><value><struct/></value></fault></methodResponse>');
     }
 
@@ -178,9 +184,9 @@ class FaultTest extends \PHPUnit_Framework_TestCase
     {
         $xml = $this->createXml();
 
-        $this->assertTrue(XmlRpc\Fault::isFault($xml), $xml);
-        $this->assertFalse(XmlRpc\Fault::isFault('foo'));
-        $this->assertFalse(XmlRpc\Fault::isFault(['foo']));
+        $this->assertTrue(Fault::isFault($xml), $xml);
+        $this->assertFalse(Fault::isFault('foo'));
+        $this->assertFalse(Fault::isFault(['foo']));
     }
 
     /**
@@ -250,7 +256,7 @@ class FaultTest extends \PHPUnit_Framework_TestCase
 
     public function testUnknownErrorIsUsedIfUnknownErrorCodeEndEmptyMessageIsPassed()
     {
-        $fault = new XmlRpc\Fault(1234);
+        $fault = new Fault(1234);
         $this->assertSame(1234, $fault->getCode());
         $this->assertSame('Unknown Error', $fault->getMessage());
     }

--- a/test/GeneratorTest.php
+++ b/test/GeneratorTest.php
@@ -9,12 +9,14 @@
 
 namespace ZendTest\XmlRpc;
 
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
 use Zend\XmlRpc\Generator\GeneratorInterface as Generator;
 
 /**
  * @group      Zend_XmlRpc
  */
-class GeneratorTest extends \PHPUnit_Framework_TestCase
+class GeneratorTest extends TestCase
 {
     /**
      * @dataProvider ZendTest\XmlRpc\TestProvider::provideGenerators
@@ -74,7 +76,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
         $variant2 = '<element>&lt;&gt;&amp;&quot;\'€</element>';
         try {
             $this->assertXml($variant1, $generator);
-        } catch (\PHPUnit_Framework_ExpectationFailedException $e) {
+        } catch (ExpectationFailedException $e) {
             $this->assertXml($variant2, $generator);
         }
     }

--- a/test/Request/HttpTest.php
+++ b/test/Request/HttpTest.php
@@ -9,20 +9,21 @@
 
 namespace ZendTest\XmlRpc\Request;
 
+use PHPUnit\Framework\TestCase;
 use Zend\XmlRpc\Request;
 use ZendTest\XmlRpc\PhpInputMock;
 
 /**
  * @group      Zend_XmlRpc
  */
-class HTTPTest extends \PHPUnit_Framework_TestCase
+class HttpTest extends TestCase
 {
     /**
      * Setup environment
      */
     public function setUp()
     {
-        $this->xml =<<<EOX
+        $this->xml = <<<EOX
 <?xml version="1.0" encoding="UTF-8"?>
 <methodCall>
     <methodName>test.userUpdate</methodName>
@@ -97,7 +98,7 @@ EOX;
 
     public function testGetFullRequest()
     {
-        $expected =<<<EOT
+        $expected = <<<EOT
 User-Agent: Zend_XmlRpc_Client
 Host: localhost
 Content-Type: text/xml
@@ -107,11 +108,6 @@ EOT;
         $expected .= $this->xml;
 
         $this->assertEquals($expected, $this->request->getFullRequest());
-    }
-
-    public function testCanPassInMethodAndParams()
-    {
-        $request = new Request\Http('foo', ['bar', 'baz']);
     }
 
     public function testExtendingClassShouldBeAbleToReceiveMethodAndParams()

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\XmlRpc;
 
+use PHPUnit\Framework\TestCase;
 use Zend\XmlRpc\Request;
 use Zend\XmlRpc\AbstractValue;
 use Zend\XmlRpc\Value;
@@ -16,7 +17,7 @@ use Zend\XmlRpc\Value;
 /**
  * @group      Zend_XmlRpc
  */
-class RequestTest extends \PHPUnit_Framework_TestCase
+class RequestTest extends TestCase
 {
     /**
      * \Zend\XmlRpc\Request object

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -263,17 +263,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $sx = new \SimpleXMLElement($xml);
 
         $result = $sx->xpath('//methodName');
-        $count = 0;
-        while (list(, $node) = each($result)) {
-            ++$count;
-        }
+        $count = count($result);
         $this->assertEquals(1, $count, $xml);
 
         $result = $sx->xpath('//params');
-        $count = 0;
-        while (list(, $node) = each($result)) {
-            ++$count;
-        }
+        $count = count($result);
         $this->assertEquals(1, $count, $xml);
 
         $methodName = (string) $sx->methodName;

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\XmlRpc;
 
+use PHPUnit\Framework\TestCase;
 use SimpleXMLElement;
 use Zend\XmlRpc\Response;
 use Zend\XmlRpc\AbstractValue;
@@ -16,7 +17,7 @@ use Zend\XmlRpc\AbstractValue;
 /**
  * @group      Zend_XmlRpc
  */
-class ResponseTest extends \PHPUnit_Framework_TestCase
+class ResponseTest extends TestCase
 {
     /**
      * Response object

--- a/test/Server/CacheTest.php
+++ b/test/Server/CacheTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\XmlRpc\Server;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\XmlRpc\Server;
 
 class CacheTest extends TestCase
@@ -52,7 +52,7 @@ class CacheTest extends TestCase
      */
     public function testGetSave()
     {
-        if (!is_writeable('./')) {
+        if (! is_writeable('./')) {
             $this->markTestIncomplete('Directory no writable');
         }
 
@@ -70,7 +70,7 @@ class CacheTest extends TestCase
      */
     public function testDelete()
     {
-        if (!is_writeable('./')) {
+        if (! is_writeable('./')) {
             $this->markTestIncomplete('Directory no writable');
         }
 
@@ -80,7 +80,7 @@ class CacheTest extends TestCase
 
     public function testShouldReturnFalseWithInvalidCache()
     {
-        if (!is_writeable('./')) {
+        if (! is_writeable('./')) {
             $this->markTestIncomplete('Directory no writable');
         }
 

--- a/test/Server/FaultTest.php
+++ b/test/Server/FaultTest.php
@@ -9,12 +9,13 @@
 
 namespace ZendTest\XmlRpc\Server;
 
+use PHPUnit\Framework\TestCase;
 use Zend\XmlRpc\Server;
 
 /**
  * @group      Zend_XmlRpc
  */
-class FaultTest extends \PHPUnit_Framework_TestCase
+class FaultTest extends TestCase
 {
     /**
      * Zend\XmlRpc\Server\Fault::getInstance() test

--- a/test/Server/TestAsset/Observer.php
+++ b/test/Server/TestAsset/Observer.php
@@ -21,7 +21,7 @@ class Observer
 
     public static function getInstance()
     {
-        if (!static::$instance) {
+        if (! static::$instance) {
             static::$instance = new self();
         }
 

--- a/test/ValueTest.php
+++ b/test/ValueTest.php
@@ -11,7 +11,9 @@ namespace ZendTest\XmlRpc;
 
 use stdClass;
 use DateTime;
+use PHPUnit\Framework\TestCase;
 use Zend\XmlRpc\AbstractValue;
+use Zend\XmlRpc\Exception;
 use Zend\XmlRpc\Value;
 use Zend\XmlRpc\Generator\GeneratorInterface as Generator;
 
@@ -20,7 +22,7 @@ use Zend\XmlRpc\Generator\GeneratorInterface as Generator;
  *
  * @group      Zend_XmlRpc
  */
-class ValueTest extends \PHPUnit_Framework_TestCase
+class ValueTest extends TestCase
 {
     public $xmlRpcDateFormat = 'Ymd\\TH:i:s';
 
@@ -113,7 +115,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalI4FromOverlongNativeThrowsException()
     {
-        $this->setExpectedException('Zend\XmlRpc\Exception\ValueException', 'Overlong integer given');
+        $this->expectException(Exception\ValueException::class);
+        $this->expectExceptionMessage('Overlong integer given');
         $x = AbstractValue::getXmlRpcValue(PHP_INT_MAX + 5000, AbstractValue::XMLRPC_TYPE_I4);
         var_dump($x);
     }
@@ -123,7 +126,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testMarshalIntegerFromOverlongNativeThrowsException()
     {
-        $this->setExpectedException('Zend\XmlRpc\Exception\ValueException', 'Overlong integer given');
+        $this->expectException(Exception\ValueException::class);
+        $this->expectExceptionMessage('Overlong integer given');
         AbstractValue::getXmlRpcValue(PHP_INT_MAX + 5000, AbstractValue::XMLRPC_TYPE_INTEGER);
     }
 
@@ -393,8 +397,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         $native = [];
         $xml    = '<value><array/></value>';
 
-        $this->setExpectedException(
-            'Zend\XmlRpc\Exception\ValueException',
+        $this->expectException(Exception\ValueException::class);
+        $this->expectExceptionMessage(
             'Invalid XML for XML-RPC native array type: ARRAY tag must contain DATA tag'
         );
         $val = AbstractValue::getXmlRpcValue($xml, AbstractValue::XML_STRING);
@@ -614,10 +618,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testMarshalDateTimeFromInvalidString()
     {
-        $this->setExpectedException(
-            'Zend\XmlRpc\Exception\ValueException',
-            'The timezone could not be found in the database'
-        );
+        $this->expectException(Exception\ValueException::class);
+        $this->expectExceptionMessage('The timezone could not be found in the database');
         AbstractValue::getXmlRpcValue('foobarbaz', AbstractValue::XMLRPC_TYPE_DATETIME);
     }
 
@@ -801,10 +803,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testFactoryThrowsWhenInvalidTypeSpecified()
     {
-        $this->setExpectedException(
-            'Zend\XmlRpc\Exception\ValueException',
-            'Given type is not a Zend\XmlRpc\AbstractValue constant'
-        );
+        $this->expectException(Exception\ValueException::class);
+        $this->expectExceptionMessage('Given type is not a Zend\XmlRpc\AbstractValue constant');
         AbstractValue::getXmlRpcValue('', 'bad type here');
     }
 
@@ -883,7 +883,7 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testGetXmlRpcTypeByValueThrowsExceptionOnInvalidValue()
     {
-        $this->setExpectedException('Zend\XmlRpc\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         AbstractValue::getXmlRpcTypeByValue(fopen(__FILE__, 'r'));
     }
 

--- a/test/autoload.php
+++ b/test/autoload.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-xmlrpc for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-xmlrpc/blob/master/LICENSE.md New BSD License
+ */
+
+/**
+ * @todo This file may be removed once we drop support for PHP 5.
+ */
+if (! class_exists(PHPUnit\Framework\ExpectationFailedException::class)) {
+    class_alias(
+        PHPUnit_Framework_ExpectationFailedException::class,
+        PHPUnit\Framework\ExpectationFailedException::class,
+        true
+    );
+}


### PR DESCRIPTION
This patch builds on #29 to ensure that the component works against PHP 7.2. It does so by doing the following:

- Upgrading PHPUnit to use either the 5.7 or 6.4 series. This required test suite updates to work, including:
  - Using namespaced PHPUnit classes.
  - Replacing `setExpectedException()` calls with relevant `expectException*()` calls.
  - Replacing `getMock()` usage with either `createMock()` or `getMockBuilder()`.
- Updating CS tooling to zend-coding-standard.
- Updating Travis to add build targets for 7.1 and 7.2.