### PR TITLE
Fixed link to PR in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- [#27](https://github.com/zendframework/zend-xmlrpc/pull/19) fixed a memory leak
+- [#27](https://github.com/zendframework/zend-xmlrpc/pull/27) fixed a memory leak
   caused by repetitive addition of `Accept` and `Content-Type` headers on subsequent
   HTTP requests produced by the `Zend\XmlRpc\Client`.
 


### PR DESCRIPTION
It's already fixed in release notes:
https://github.com/zendframework/zend-xmlrpc/releases/tag/release-2.6.1