### PR TITLE
Disable bigint for 64 bit machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+Disables use of BigInteger for XMLRPC i8 type if host machine is 64-bit.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
+- [#40](https://github.com/zendframework/zend-xmlrpc/pull/40) modifies detection of integer values on 64-bit systems. Previously, i8 values parsed by the client were always cast to BigInteger values. Now, on 64-bit systems, they are cast to integers.
+
 Disables use of BigInteger for XMLRPC i8 type if host machine is 64-bit.
 
 ### Deprecated

--- a/docs/book/client.md
+++ b/docs/book/client.md
@@ -133,8 +133,8 @@ XML-RPC Type     | `Zend\XmlRpc\AbstractValue` Constant               | `Zend\Xm
 ---------------- | -------------------------------------------------- | --------------------------
 int              | `Zend\XmlRpc\AbstractValue::XMLRPC_TYPE_INTEGER`   | `Zend\XmlRpc\Value\Integer`
 i4               | `Zend\XmlRpc\AbstractValue::XMLRPC_TYPE_I4`        | `Zend\XmlRpc\Value\Integer`
-i8               | `Zend\XmlRpc\AbstractValue::XMLRPC_TYPE_I8`        | `Zend\XmlRpc\Value\BigInteger`
-ex:i8            | `Zend\XmlRpc\AbstractValue::XMLRPC_TYPE_APACHEI8`  | `Zend\XmlRpc\Value\BigInteger`
+i8               | `Zend\XmlRpc\AbstractValue::XMLRPC_TYPE_I8`        | `Zend\XmlRpc\Value\BigInteger` or `Zend\XmlRpc\Value\Integer` if machine is 64-bit
+ex:i8            | `Zend\XmlRpc\AbstractValue::XMLRPC_TYPE_APACHEI8`  | `Zend\XmlRpc\Value\BigInteger` or `Zend\XmlRpc\Value\Integer` if machine is 64-bit
 double           | `Zend\XmlRpc\AbstractValue::XMLRPC_TYPE_DOUBLE`    | `Zend\XmlRpc\ValueDouble`
 boolean          | `Zend\XmlRpc\AbstractValue::XMLRPC_TYPE_BOOLEAN`   | `Zend\XmlRpc\Value\Boolean`
 string           | `Zend\XmlRpc\AbstractValue::XMLRPC_TYPE_STRING`    | `Zend\XmlRpc\Value\Text`

--- a/src/AbstractValue.php
+++ b/src/AbstractValue.php
@@ -44,14 +44,17 @@ abstract class AbstractValue
     protected $xml;
 
     /**
+     * True if BigInteger should be used for XMLRPC i8 types
+     *
+     * @internal
+     * @var bool
+     */
+    public static $USE_BIGINT_FOR_I8 = PHP_INT_SIZE < 8;
+
+    /**
      * @var \Zend\XmlRpc\Generator\GeneratorInterface
      */
     protected static $generator;
-
-    /**
-     * True if BigInteger should be used for XMLRPC i8 types
-     */
-    public static $USE_BIGINT_FOR_I8 = PHP_INT_SIZE < 8;
 
     /**
      * Specify that the XML-RPC native type will be auto detected from a PHP variable type

--- a/src/AbstractValue.php
+++ b/src/AbstractValue.php
@@ -49,6 +49,11 @@ abstract class AbstractValue
     protected static $generator;
 
     /**
+     * True if BigInteger should be used for XMLRPC i8 types
+     */
+    public static $USE_BIGINT_FOR_I8 = PHP_INT_SIZE < 8;
+
+    /**
      * Specify that the XML-RPC native type will be auto detected from a PHP variable type
      */
     const AUTO_DETECT_TYPE = 'auto_detect';
@@ -193,7 +198,7 @@ abstract class AbstractValue
             case self::XMLRPC_TYPE_I8:
                 // fall through to the next case
             case self::XMLRPC_TYPE_APACHEI8:
-                return new Value\BigInteger($value);
+                return self::$USE_BIGINT_FOR_I8 ? new Value\BigInteger($value) : new Value\Integer($value);
 
             case self::XMLRPC_TYPE_DOUBLE:
                 return new Value\Double($value);
@@ -337,7 +342,7 @@ abstract class AbstractValue
             case self::XMLRPC_TYPE_APACHEI8:
                 // Fall through to the next case
             case self::XMLRPC_TYPE_I8:
-                $xmlrpcValue = new Value\BigInteger($value);
+                $xmlrpcValue = self::$USE_BIGINT_FOR_I8 ? new Value\BigInteger($value) : new Value\Integer($value);
                 break;
             case self::XMLRPC_TYPE_DOUBLE:
                 $xmlrpcValue = new Value\Double($value);

--- a/test/BigIntegerValueTest.php
+++ b/test/BigIntegerValueTest.php
@@ -21,6 +21,7 @@ class BigIntegerValueTest extends TestCase
 {
     public function setUp()
     {
+        AbstractValue::$USE_BIGINT_FOR_I8 = true;
         if (extension_loaded('gmp')) {
             $this->markTestSkipped('gmp causes test failure');
         }


### PR DESCRIPTION
This PR disables BigInteger if the machine is 64-bit. Currently, when an i8 type is received from the XMLRPC server, the client converts the value to a BigInteger. But now, if the machine is 64-bit, it will simply convert the value to a standard Integer. 